### PR TITLE
fix: downgrade SDK to 3.2.1 and set minSdkVersion to 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,11 +42,11 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 33
     }
 }
 
 dependencies {
-    implementation 'io.piano:analytics:3.3.4'
+    implementation 'io.piano:analytics:3.2.1'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.plugin.example.piano_analytics_plugin_example"
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
- Downgrading the SDK version to 3.2.1 since the main branch cannot compile in it's current state.
- Setting the `minSdkVersion` version to 21 in order to match the SDK's configuration 

_**Disclaimer** : I'm not using the SDK, I didn't take the time to try this fix on a working project_